### PR TITLE
STD in ivmarkov/rust:stable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/espressif/llvm-project
-	branch = xtensa_release_10.0.1
+	branch = xtensa_release_11.0.0
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,8 +36,8 @@
 	url = https://github.com/rust-lang/edition-guide.git
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/11.0-2020-10-12
+	url = https://github.com/espressif/llvm-project
+	branch = xtensa_release_10.0.1
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,4 @@
 [submodule "library/backtrace"]
 	path = library/backtrace
 	url = https://github.com/ivmarkov/backtrace-rs.git
+	branch = esp-idf

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,4 +46,4 @@
 	url = https://github.com/rust-analyzer/rust-analyzer.git
 [submodule "library/backtrace"]
 	path = library/backtrace
-	url = https://github.com/rust-lang/backtrace-rs.git
+	url = https://github.com/ivmarkov/backtrace-rs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,4 +47,3 @@
 [submodule "library/backtrace"]
 	path = library/backtrace
 	url = https://github.com/ivmarkov/backtrace-rs.git
-	branch = esp-idf

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ $ which llvm-config
 
 The above should output locations pointing at your custom-built clang toolchain.
 
-**NOTE**: You might want to make the PATH modification step from above permanent. Please make sure that the custom clang compiler is the first on your PATH so that it takes precedence over any clang compiler you might have installed using your distro / OS. Otherwise, you might be greeted with a strange build error when building the ["Hello, World" demo app](https://github.com/ivmarkov/rust-esp32-std-hello):
+* **NOTE 1**: Building LLVM clang might take **even longer** time than building the Rustc toolchain!
+* **NOTE 2**: You might want to make the PATH modification step from above permanent. Please make sure that the custom clang compiler is the first on your PATH so that it takes precedence over any clang compiler you might have installed using your distro / OS. Otherwise, you might be greeted with a strange build error when building the ["Hello, World" demo app](https://github.com/ivmarkov/rust-esp32-std-hello):
 ```
   thread 'main' panicked at 'libclang error; possible causes include:
   - Invalid flag syntax

--- a/README.md
+++ b/README.md
@@ -1,268 +1,86 @@
-<a href = "https://www.rust-lang.org/">
-<img width = "90%" height = "auto" src = "https://img.shields.io/badge/Rust-Programming%20Language-black?style=flat&logo=rust" alt = "The Rust Programming Language">
-</a>
+# A fork of the Rust compiler for ESP, with STD support
 
-This is the main source code repository for [Rust]. It contains the compiler,
-standard library, and documentation.
+This fork enables projects to be built for the ESP32 and ESP8266 using [espressif's llvm fork](https://github.com/espressif/llvm-project).
+Moreover, the fork contains a port of [Rust](https://github.com/rust-lang/rust)'s STD lib on top of the ESP-IDF libraries.
 
-[Rust]: https://www.rust-lang.org
+The repo is essentially a (more recent) fork of the original work of [MabezDev](https://github.com/MabezDev/rust-xtensa) which enables support in Rust for the Xtensa/ESP8266/ESP32 targets.
+... plus a set of extensions of the std library so that it can compile and run on top of ESP-IDF.
 
-**Note: this README is for _users_ rather than _contributors_.
-If you wish to _contribute_ to the compiler, you should read the
-[Getting Started][gettingstarted] section of the rustc-dev-guide instead.**
+## Background
 
-## Quick Start
+A few words on the approach taken for bringing STD support to the ESP platform:
+* Even though the ESPs are considered "bare metal", the ESP-IDF framework of Espressif is actually a relatively complete Posix layer
+* If you squint a little, you can even pretend that an ESP running the ESP-IDF framework - from the point of view of the app on top - looks like a real Unix. That's because ESP-IDF has a libc (newlib), BSD sockets layer (lwip), pthread support (running on top of FreeRTOS) and quite a few other unix/posix APIs. It also uses GCC, elf and does have a port of LLVM (as per above)
+* So besides the process and env APIs which are obviously not available on the ESP, everything else looks like regular unix/posix C API layer
 
-Read ["Installation"] from [The Book].
+Therefore, the STD support for ESP is implemented inside Rust's standard std::sys::unix modules and more or less boils down to stubbing out functionality which is not available in ESP-IDF. The whole ESP STD patch-set is having currently the miniscule size of ~500-1000 LOCs.
 
-["Installation"]: https://doc.rust-lang.org/book/ch01-01-installation.html
-[The Book]: https://doc.rust-lang.org/book/index.html
+## Disclaimer
 
-## Installing from Source
+STD for ESP **does** require the ESP-IDF toolkit and **does** call into ESP-IDF. This is contrary to [other efforts (esp-rs) related to running Rust on ESP](https://github.com/esp-rs), which are trying to avoid any dependencies on the vendor-provided software stack.
 
-The Rust build system uses a Python script called `x.py` to build the compiler,
-which manages the bootstrapping process. More information about it can be found
-by running `./x.py --help` or reading the [rustc dev guide][rustcguidebuild].
+## Forum
 
-[gettingstarted]: https://rustc-dev-guide.rust-lang.org/getting-started.html
-[rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
+Rust on ESP seems to be discussed here: https://matrix.to/#/#esp-rs:matrix.org!
 
-### Building on a Unix-like system
-1. Make sure you have installed the dependencies:
+## "Hello, World" demo app
 
-   * `g++` 5.1 or later or `clang++` 3.5 or later
-   * `python` 3 or 2.7
-   * GNU `make` 3.81 or later
-   * `cmake` 3.4.3 or later
-   * `ninja`
-   * `curl`
-   * `git`
-   * `ssl` which comes in `libssl-dev` or `openssl-devel`
-   * `pkg-config` if you are compiling on Linux and targeting Linux
+[Here](https://github.com/ivmarkov/rust-esp32-std-hello)
 
-2. Clone the [source] with `git`:
+## Building
 
-   ```sh
-   git clone https://github.com/rust-lang/rust.git
-   cd rust
-   ```
+Install [Rustup](https://rustup.rs/).
 
-[source]: https://github.com/rust-lang/rust
+Build using these steps (NOTE: building might take **close to an hour**!):
+```sh
+$ cd <some directory where you'll keep the compiler binaries and its sources; you'll need to keep the whole GIT repo, because xargo/cargo need those when building your ESP32 crates>
+$ git clone https://github.com/ivmarkov/rust
+$ cd rust
+$ ./configure --experimental-targets=Xtensa
+$ ./x.py build --stage 2
+```
 
-3. Configure the build settings:
-
-    The Rust build system uses a file named `config.toml` in the root of the
-    source tree to determine various configuration settings for the build.
-    Copy the default `config.toml.example` to `config.toml` to get started.
-
-    ```sh
-    cp config.toml.example config.toml
-    ```
-
-    If you plan to use `x.py install` to create an installation, it is recommended
-    that you set the `prefix` value in the `[install]` section to a directory.
-
-    Create install directory if you are not installing in default directory
-
-4. Build and install:
-
-    ```sh
-    ./x.py build && ./x.py install
-    ```
-
-    When complete, `./x.py install` will place several programs into
-    `$PREFIX/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
-    API-documentation tool. This install does not include [Cargo],
-    Rust's package manager. To build and install Cargo, you may
-    run `./x.py install cargo` or set the `build.extended` key in
-    `config.toml` to `true` to build and install all tools.
-
-[Cargo]: https://github.com/rust-lang/cargo
-
-### Building on Windows
-
-There are two prominent ABIs in use on Windows: the native (MSVC) ABI used by
-Visual Studio, and the GNU ABI used by the GCC toolchain. Which version of Rust
-you need depends largely on what C/C++ libraries you want to interoperate with:
-for interop with software produced by Visual Studio use the MSVC build of Rust;
-for interop with GNU software built using the MinGW/MSYS2 toolchain use the GNU
-build.
-
-#### MinGW
-
-[MSYS2][msys2] can be used to easily build Rust on Windows:
-
-[msys2]: https://msys2.github.io/
-
-1. Grab the latest [MSYS2 installer][msys2] and go through the installer.
-
-2. Run `mingw32_shell.bat` or `mingw64_shell.bat` from wherever you installed
-   MSYS2 (i.e. `C:\msys64`), depending on whether you want 32-bit or 64-bit
-   Rust. (As of the latest version of MSYS2 you have to run `msys2_shell.cmd
-   -mingw32` or `msys2_shell.cmd -mingw64` from the command line instead)
-
-3. From this terminal, install the required tools:
-
-   ```sh
-   # Update package mirrors (may be needed if you have a fresh install of MSYS2)
-   pacman -Sy pacman-mirrors
-
-   # Install build tools needed for Rust. If you're building a 32-bit compiler,
-   # then replace "x86_64" below with "i686". If you've already got git, python,
-   # or CMake installed and in PATH you can remove them from this list. Note
-   # that it is important that you do **not** use the 'python2', 'cmake' and 'ninja'
-   # packages from the 'msys2' subsystem. The build has historically been known
-   # to fail with these packages.
-   pacman -S git \
-               make \
-               diffutils \
-               tar \
-               mingw-w64-x86_64-python \
-               mingw-w64-x86_64-cmake \
-               mingw-w64-x86_64-gcc \
-               mingw-w64-x86_64-ninja
-   ```
-
-4. Navigate to Rust's source code (or clone it), then build it:
-
-   ```sh
-   ./x.py build && ./x.py install
-   ```
-
-#### MSVC
-
-MSVC builds of Rust additionally require an installation of Visual Studio 2017
-(or later) so `rustc` can use its linker.  The simplest way is to get the
-[Visual Studio], check the “C++ build tools” and “Windows 10 SDK” workload.
-
-[Visual Studio]: https://visualstudio.microsoft.com/downloads/
-
-(If you're installing cmake yourself, be careful that “C++ CMake tools for
-Windows” doesn't get included under “Individual components”.)
-
-With these dependencies installed, you can build the compiler in a `cmd.exe`
-shell with:
+Make Rustup aware of the newly built compiler:
 
 ```sh
-python x.py build
+$ rustup toolchain link xtensa ~/<...>/rust/build/x86_64-unknown-linux-gnu/stage2
 ```
 
-Currently, building Rust only works with some known versions of Visual Studio. If
-you have a more recent version installed and the build system doesn't understand,
-you may need to force rustbuild to use an older version. This can be done
-by manually calling the appropriate vcvars file before running the bootstrap.
-
-```batch
-CALL "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
-python x.py build
-```
-
-#### Specifying an ABI
-
-Each specific ABI can also be used from either environment (for example, using
-the GNU ABI in PowerShell) by using an explicit build triple. The available
-Windows build triples are:
-- GNU ABI (using GCC)
-    - `i686-pc-windows-gnu`
-    - `x86_64-pc-windows-gnu`
-- The MSVC ABI
-    - `i686-pc-windows-msvc`
-    - `x86_64-pc-windows-msvc`
-
-The build triple can be specified by either specifying `--build=<triple>` when
-invoking `x.py` commands, or by copying the `config.toml` file (as described
-in [Installing From Source](#installing-from-source)), and modifying the
-`build` option under the `[build]` section.
-
-### Configure and Make
-
-While it's not the recommended build system, this project also provides a
-configure script and makefile (the latter of which just invokes `x.py`).
+Switch to the new compiler in Rustup:
 
 ```sh
-./configure
-make && sudo make install
+$ rustup default xtensa
 ```
 
-When using the configure script, the generated `config.mk` file may override the
-`config.toml` file. To go back to the `config.toml` file, delete the generated
-`config.mk` file.
+Check the compiler:
+```sh
+$ rustc --print target-list
+```
 
-## Building Documentation
+At the end of the printed list of targets you should see:
+```
+...
+xtensa-esp32-none-elf
+xtensa-esp8266-none-elf
+xtensa-none-elf
+```
 
-If you’d like to build the documentation, it’s almost the same:
+### Optional steps
+
+Install xargo (you'll need it when building your ESP32 crates, because `cargo -Z build-std` corrently does not seem to work):
 
 ```sh
-./x.py doc
+$ cargo install xargo
 ```
 
-The generated documentation will appear under `doc` in the `build` directory for
-the ABI used. I.e., if the ABI was `x86_64-pc-windows-msvc`, the directory will be
-`build\x86_64-pc-windows-msvc\doc`.
+Set xargo's XARGO_RUST_SRC dir:
 
-## Notes
+```sh
+export XARGO_RUST_SRC=`rustc --print sysroot`/lib/rustlib/src/rust/library
+```
 
-Since the Rust compiler is written in Rust, it must be built by a
-precompiled "snapshot" version of itself (made in an earlier stage of
-development). As such, source builds require a connection to the Internet, to
-fetch snapshots, and an OS that can execute the available snapshot binaries.
+... and probably put that line at the end of `~/.profile`, `~/.bash_profile` or `~/.bashrc` but make sure it is executed **after** the modification of $PATH with `~/.cargo/bin` by Rustup
+ 
+## Updating this fork
 
-Snapshot binaries are currently built and tested on several platforms:
-
-| Platform / Architecture                     | x86 | x86_64 |
-|---------------------------------------------|-----|--------|
-| Windows (7, 8, 10, ...)                     | ✓   | ✓      |
-| Linux (kernel 2.6.32, glibc 2.11 or later)  | ✓   | ✓      |
-| macOS (10.7 Lion or later)                  | (\*) | ✓      |
-
-(\*): Apple dropped support for running 32-bit binaries starting from macOS 10.15 and iOS 11.
-Due to this decision from Apple, the targets are no longer useful to our users.
-Please read [our blog post][macx32] for more info.
-
-[macx32]: https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html
-
-You may find that other platforms work, but these are our officially
-supported build environments that are most likely to work.
-
-## Getting Help
-
-The Rust community congregates in a few places:
-
-* [Stack Overflow] - Direct questions about using the language.
-* [users.rust-lang.org] - General discussion and broader questions.
-* [/r/rust] - News and general discussion.
-
-[Stack Overflow]: https://stackoverflow.com/questions/tagged/rust
-[/r/rust]: https://reddit.com/r/rust
-[users.rust-lang.org]: https://users.rust-lang.org/
-
-## Contributing
-
-If you are interested in contributing to the Rust project, please take a look
-at the [Getting Started][gettingstarted] guide in the [rustc-dev-guide].
-
-[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org
-
-## License
-
-Rust is primarily distributed under the terms of both the MIT license
-and the Apache License (Version 2.0), with portions covered by various
-BSD-like licenses.
-
-See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), and
-[COPYRIGHT](COPYRIGHT) for details.
-
-## Trademark
-
-The Rust programming language is an open source, community project governed
-by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”),
-which owns and protects the Rust and Cargo trademarks and logos
-(the “Rust Trademarks”).
-
-If you want to use these names or brands, please read the [media guide][media-guide].
-
-Third-party logos may be subject to third-party copyrights and trademarks. See
-[Licenses][policies-licenses] for details.
-
-[media-guide]: https://www.rust-lang.org/policies/media-guide
-[policies-licenses]: https://www.rust-lang.org/policies/licenses
+TBD: https://github.com/ivmarkov/rust-xtensa-patches

--- a/README.md
+++ b/README.md
@@ -38,10 +38,22 @@ Build using these steps (NOTE 1: building might take **close to an hour**! NOTE 
 ```sh
 $ cd <some directory where you'll keep the compiler binaries and its sources; you'll need to keep the whole GIT repo, because xargo/cargo need those when building your ESP32 crates>
 $ git clone https://github.com/ivmarkov/rust
-$ git checkout stable
 $ cd rust
+$ git checkout stable
 $ ./configure --experimental-targets=Xtensa
 $ ./x.py build --stage 2
+```
+
+### Fix toolchain vendor/ directory, so that building STD with Cargo does work
+
+(Assuming you are still in the rust/ directory):
+
+```sh
+$ mkdir vendor
+$ cd vendor
+$ ln -s ../library/rustc-std-workspace-alloc/ rustc-std-workspace-alloc
+$ ln -s ../library/rustc-std-workspace-core/ rustc-std-workspace-core
+$ ln -s ../library/rustc-std-workspace-std/ rustc-std-workspace-std
 ```
 
 Make Rustup aware of the newly built compiler:
@@ -71,7 +83,7 @@ xtensa-none-elf
 
 ### Optional steps
 
-Install xargo (optional because `cargo build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort` seems to work again):
+Install xargo (optional because `cargo build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort` seems to work again, given that the 'Fix toolchain vendor/ directory' step from above is performed):
 
 ```sh
 $ cargo install xargo

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 This fork enables projects to be built for the ESP32 and ESP8266 using [espressif's llvm fork](https://github.com/espressif/llvm-project).
 Moreover, the fork contains a port of [Rust](https://github.com/rust-lang/rust)'s STD lib on top of the ESP-IDF libraries.
 
-The repo is essentially a (more recent) fork of the original work of [MabezDev](https://github.com/MabezDev/rust-xtensa) which enables support in Rust for the Xtensa/ESP8266/ESP32 targets.
-... plus a set of extensions of the std library so that it can compile and run on top of ESP-IDF.
+The repo is essentially a copy of the work of [MabezDev](https://github.com/MabezDev/rust-xtensa) which enables support in Rust for the Xtensa/ESP8266/ESP32 targets.
+<br>... plus a set of extensions of the std library so that it can compile and run on top of ESP-IDF.
 
 ## Background
 
 A few words on the approach taken for bringing STD support to the ESP platform:
 * Even though the ESPs are considered "bare metal", the ESP-IDF framework of Espressif is actually a relatively complete Posix layer
-* If you squint a little, you can even pretend that an ESP running the ESP-IDF framework - from the point of view of the app on top - looks like a real Unix. That's because ESP-IDF has a libc (newlib), BSD sockets layer (lwip), pthread support (running on top of FreeRTOS) and quite a few other unix/posix APIs. It also uses GCC, elf and does have a port of LLVM (as per above)
+* If you squint a little, you can even pretend that an ESP running the ESP-IDF framework - from the point of view of the app on top - looks like a real Unix. That's because ESP-IDF has a libc (newlib), BSD sockets layer (lwIP), pthread support (running on top of FreeRTOS) and quite a few other unix/posix APIs. It also uses GCC, elf and does have a port of LLVM (as per above)
 * So besides the process and env APIs which are obviously not available on the ESP, everything else looks like regular unix/posix C API layer
 
 Therefore, the STD support for ESP is implemented inside Rust's standard std::sys::unix modules and more or less boils down to stubbing out functionality which is not available in ESP-IDF. The whole ESP STD patch-set is having currently the miniscule size of ~500-1000 LOCs.
@@ -19,11 +19,14 @@ Therefore, the STD support for ESP is implemented inside Rust's standard std::sy
 
 STD for ESP **does** require the ESP-IDF toolkit and **does** call into ESP-IDF. This is contrary to [other efforts (esp-rs) related to running Rust on ESP](https://github.com/esp-rs), which are trying to avoid any dependencies on the vendor-provided software stack.
 
+* ... but what you get as a result is the full power of ESP-IDF and the ability to interoperate with other libraries built on top of ESP-IDF!
+* ... and type-safe wrappers for various ESP-IDF services: [WiFi](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/wifi.rs), [Network](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/netif.rs), [HTTP Server](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/httpd.rs), [Ping](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/ping.rs), [Logging](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/log.rs), [Flash Storage (soon)](https://github.com/ivmarkov/esp-idf-svc/blob/master/src/nvs_storage.rs). These come as a set of [abstractions](https://github.com/ivmarkov/embedded-svc) similar in spirit to [embedded-hal](https://github.com/rust-embedded/embedded-hal) and are designed to be portable to other boards (**RPI0 anyone**?). Of course, all of those with [implementations for the  ESP32/ESP-IDF](https://github.com/ivmarkov/esp-idf-svc/).
+
 ## Forum
 
 Rust on ESP seems to be discussed here: https://matrix.to/#/#esp-rs:matrix.org!
 
-## "Hello, World" demo app
+## ["Hello, World" demo app](https://github.com/ivmarkov/rust-esp32-std-hello)
 
 [Here](https://github.com/ivmarkov/rust-esp32-std-hello)
 
@@ -31,10 +34,11 @@ Rust on ESP seems to be discussed here: https://matrix.to/#/#esp-rs:matrix.org!
 
 Install [Rustup](https://rustup.rs/).
 
-Build using these steps (NOTE: building might take **close to an hour**!):
+Build using these steps (NOTE 1: building might take **close to an hour**! NOTE 2: Please use the `stable` branch, which is based on MabezDev Stable, which in turn is based on Rust 1.50.0):
 ```sh
 $ cd <some directory where you'll keep the compiler binaries and its sources; you'll need to keep the whole GIT repo, because xargo/cargo need those when building your ESP32 crates>
 $ git clone https://github.com/ivmarkov/rust
+$ git checkout stable
 $ cd rust
 $ ./configure --experimental-targets=Xtensa
 $ ./x.py build --stage 2
@@ -67,7 +71,7 @@ xtensa-none-elf
 
 ### Optional steps
 
-Install xargo (you'll need it when building your ESP32 crates, because `cargo -Z build-std` corrently does not seem to work):
+Install xargo (optional because `cargo build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort` seems to work again):
 
 ```sh
 $ cargo install xargo
@@ -80,7 +84,7 @@ export XARGO_RUST_SRC=`rustc --print sysroot`/lib/rustlib/src/rust/library
 ```
 
 ... and probably put that line at the end of `~/.profile`, `~/.bash_profile` or `~/.bashrc` but make sure it is executed **after** the modification of $PATH with `~/.cargo/bin` by Rustup
- 
+
 ## Updating this fork
 
 TBD: https://github.com/ivmarkov/rust-xtensa-patches

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -86,6 +86,7 @@ fn main() {
         "nvptx",
         "hexagon",
         "riscv",
+        "xtensa"
     ];
 
     let mut version_cmd = Command::new(&llvm_config);

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -231,6 +231,12 @@ void LLVMRustAddLastExtensionPasses(
 #define SUBTARGET_SPARC
 #endif
 
+#ifdef LLVM_COMPONENT_XTENSA
+#define SUBTARGET_XTENSA SUBTARGET(XTENSA)
+#else
+#define SUBTARGET_XTENSA
+#endif
+
 #ifdef LLVM_COMPONENT_HEXAGON
 #define SUBTARGET_HEXAGON SUBTARGET(Hexagon)
 #else
@@ -248,6 +254,7 @@ void LLVMRustAddLastExtensionPasses(
   SUBTARGET_MSP430                                                             \
   SUBTARGET_SPARC                                                              \
   SUBTARGET_HEXAGON                                                            \
+  SUBTARGET_XTENSA                                                             \
   SUBTARGET_RISCV                                                              \
 
 #define SUBTARGET(x)                                                           \

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -163,6 +163,14 @@ pub fn initialize_available_targets() {
         LLVMInitializeHexagonAsmParser
     );
     init_target!(
+        llvm_component = "xtensa",
+        LLVMInitializeXtensaTargetInfo,
+        LLVMInitializeXtensaTarget,
+        LLVMInitializeXtensaTargetMC,
+        LLVMInitializeXtensaAsmPrinter,
+        LLVMInitializeXtensaAsmParser
+    );
+    init_target!(
         llvm_component = "webassembly",
         LLVMInitializeWebAssemblyTargetInfo,
         LLVMInitializeWebAssemblyTarget,

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -7,6 +7,7 @@ mod amdgpu;
 mod arm;
 mod avr;
 mod hexagon;
+mod xtensa;
 mod mips;
 mod mips64;
 mod msp430;
@@ -604,6 +605,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "nvptx" => nvptx::compute_abi_info(self),
             "nvptx64" => nvptx64::compute_abi_info(self),
             "hexagon" => hexagon::compute_abi_info(self),
+            "xtensa" => xtensa::compute_abi_info(cx, self),
             "riscv32" | "riscv64" => riscv::compute_abi_info(cx, self),
             "wasm32" if cx.target_spec().os != "emscripten" => {
                 wasm32_bindgen_compat::compute_abi_info(self)

--- a/compiler/rustc_target/src/abi/call/xtensa.rs
+++ b/compiler/rustc_target/src/abi/call/xtensa.rs
@@ -1,0 +1,110 @@
+// reference: https://github.com/MabezDev/llvm-project/blob/xtensa_release_9.0.1_with_rust_patches-31-05-2020-cherry-pick/clang/lib/CodeGen/TargetInfo.cpp#L9668-L9767
+
+use crate::abi::call::{ArgAbi, FnAbi, Reg, Uniform};
+use crate::abi::{HasDataLayout, LayoutOf,  TyAndLayout, TyAndLayoutMethods,Abi, Size};
+use crate::spec::HasTargetSpec;
+
+const NUM_ARG_GPRS: u64 = 6;
+const MAX_ARG_IN_REGS_SIZE: u64 = 4 * 32;
+const MAX_RET_IN_REGS_SIZE: u64 = 2 * 32;
+
+fn classify_ret_ty<Ty>(arg: &mut ArgAbi<'_, Ty>, xlen: u64) {
+    if arg.is_ignore() {
+        return;
+    }
+
+    // The rules for return and argument types are the same,
+    // so defer to `classify_arg_ty`.
+    let mut arg_gprs_left = 2;
+    let fixed = true;
+    classify_arg_ty(arg, xlen, fixed, &mut arg_gprs_left);
+}
+
+fn classify_arg_ty<Ty>(arg: &mut ArgAbi<'_, Ty>, xlen: u64, fixed: bool, arg_gprs_left: &mut u64) {
+    assert!(*arg_gprs_left <= NUM_ARG_GPRS, "Arg GPR tracking underflow");
+
+    // Ignore empty structs/unions.
+    if arg.layout.is_zst() {
+        return;
+    }
+
+    let size = arg.layout.size.bits();
+    let needed_align = arg.layout.align.abi.bits();
+    let mut must_use_stack = false;
+
+    // Determine the number of GPRs needed to pass the current argument
+    // according to the ABI. 2*XLen-aligned varargs are passed in "aligned"
+    // register pairs, so may consume 3 registers.
+    let mut needed_arg_gprs = 1u64;
+
+    if !fixed && needed_align == 2 * xlen {
+        needed_arg_gprs = 2 + (*arg_gprs_left % 2);
+    } else if size > xlen && size <= MAX_ARG_IN_REGS_SIZE {
+        needed_arg_gprs = (size + xlen - 1) / xlen;
+    }
+
+    if needed_arg_gprs > *arg_gprs_left {
+        must_use_stack = true;
+        needed_arg_gprs = *arg_gprs_left;
+    }
+    *arg_gprs_left -= needed_arg_gprs;
+
+    if !arg.layout.is_aggregate() && !matches!(arg.layout.abi, Abi::Vector { .. }) {
+        // All integral types are promoted to `xlen`
+        // width, unless passed on the stack.
+        if size < xlen && !must_use_stack {
+            arg.extend_integer_width_to(xlen);
+            return;
+        }
+
+        return;
+    }
+
+    // Aggregates which are <= 4 * 32 will be passed in
+    // registers if possible, so coerce to integers.
+    if size as u64 <= MAX_ARG_IN_REGS_SIZE {
+        let alignment = arg.layout.align.abi.bits();
+
+        // Use a single `xlen` int if possible, 2 * `xlen` if 2 * `xlen` alignment
+        // is required, and a 2-element `xlen` array if only `xlen` alignment is
+        // required.
+        if size <= xlen {
+            arg.cast_to(Reg::i32());
+            return;
+        } else if alignment == 2 * xlen {
+            arg.cast_to(Reg::i64());
+            return;
+        } else {
+            let total = Size::from_bits(((size + xlen - 1) / xlen) * xlen);
+            arg.cast_to(Uniform { unit: Reg::i32(), total });
+            return;
+        }
+    }
+
+    arg.make_indirect();
+}
+
+pub fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAndLayoutMethods<'a, C> + Copy,
+    C: LayoutOf<Ty = Ty, TyAndLayout = TyAndLayout<'a, Ty>> + HasDataLayout + HasTargetSpec,
+{
+    let xlen = cx.data_layout().pointer_size.bits();
+
+    if !fn_abi.ret.is_ignore() {
+        classify_ret_ty(&mut fn_abi.ret, xlen);
+    }
+
+    let is_ret_indirect =
+        fn_abi.ret.is_indirect() || fn_abi.ret.layout.size.bits() > MAX_RET_IN_REGS_SIZE;
+
+    let mut arg_gprs_left = if is_ret_indirect { NUM_ARG_GPRS - 1 } else { NUM_ARG_GPRS };
+
+    for arg in &mut fn_abi.args {
+        if arg.is_ignore() {
+            continue;
+        }
+        let fixed = true;
+        classify_arg_ty(arg, xlen, fixed, &mut arg_gprs_left);
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -651,6 +651,10 @@ supported_targets! {
 
     ("nvptx64-nvidia-cuda", nvptx64_nvidia_cuda),
 
+    ("xtensa-esp32-none-elf", xtensa_esp32_none_elf),
+    ("xtensa-esp8266-none-elf", xtensa_esp8266_none_elf),
+    ("xtensa-none-elf", xtensa_none_elf),
+
     ("i686-wrs-vxworks", i686_wrs_vxworks),
     ("x86_64-wrs-vxworks", x86_64_wrs_vxworks),
     ("armv7-wrs-vxworks-eabihf", armv7_wrs_vxworks_eabihf),

--- a/compiler/rustc_target/src/spec/xtensa_esp32_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32_none_elf.rs
@@ -1,0 +1,49 @@
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, RelocModel};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "xtensa-none-elf".to_string(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".to_string(),
+        arch: "xtensa".to_string(),
+        pointer_width: 32,
+
+        options: TargetOptions {
+            os_family: Some("unix".to_string()),
+            os: "none".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+
+            cpu: "esp32".to_string(),
+            endian: "little".to_string(),
+            c_int_width: "32".to_string(),
+            max_atomic_width: Some(32),
+
+            executables: true,
+
+            linker: Some("xtensa-esp32-elf-gcc".to_string()),
+            linker_flavor: LinkerFlavor::Gcc,
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: RelocModel::Static,
+
+            emit_debug_gdb_scripts: false,
+
+            unsupported_abis: vec![
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Win64,
+                Abi::SysV64,
+            ],
+
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/xtensa_esp8266_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp8266_none_elf.rs
@@ -1,0 +1,49 @@
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, RelocModel};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "xtensa-none-elf".to_string(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".to_string(),
+        arch: "xtensa".to_string(),
+        pointer_width: 32,
+
+        options: TargetOptions {
+            os_family: Some("unix".to_string()),
+            os: "none".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+    
+            cpu: "esp8266".to_string(),
+            endian: "little".to_string(),
+            c_int_width: "32".to_string(),
+            max_atomic_width: Some(32),
+
+            executables: true,
+
+            linker: Some("xtensa-lx106-elf-gcc".to_string()),
+            linker_flavor: LinkerFlavor::Gcc,
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: RelocModel::Static,
+
+            emit_debug_gdb_scripts: false,
+
+            unsupported_abis: vec![
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Win64,
+                Abi::SysV64,
+            ],
+
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/xtensa_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_none_elf.rs
@@ -1,0 +1,47 @@
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, RelocModel};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "xtensa-none-elf".to_string(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".to_string(),
+        arch: "xtensa".to_string(),
+        pointer_width: 32,
+
+        options: TargetOptions {
+            os: "none".to_string(),
+            env: String::new(),
+            vendor: String::new(),
+            
+            endian: "little".to_string(),
+            c_int_width: "32".to_string(),
+            max_atomic_width: Some(32),
+
+            executables: true,
+
+            linker: Some("xtensa-esp32-elf-gcc".to_string()),
+            linker_flavor: LinkerFlavor::Gcc,
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: RelocModel::Static,
+
+            emit_debug_gdb_scripts: false,
+
+            unsupported_abis: vec![
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Win64,
+                Abi::SysV64,
+            ],
+
+            ..Default::default()
+        },
+    }
+}

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -50,7 +50,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         all(target_family = "windows", target_env = "gnu"),
         target_os = "psp",
-        target_family = "unix",
+        all(target_family = "unix", not(target_env = "newlib")),
         all(target_vendor = "fortanix", target_env = "sgx"),
     ))] {
         // Rust runtime's startup objects depend on these symbols, so make them public.

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -26,6 +26,7 @@ fn main() {
         || target.contains("vxworks")
         || target.contains("wasm32")
         || target.contains("asmjs")
+        || target.contains("esp32")
     {
         // These platforms don't have any special requirements.
     } else {

--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -70,5 +70,7 @@ pub mod solaris;
 pub mod vxworks;
 #[cfg(target_os = "wasi")]
 pub mod wasi;
+#[cfg(all(target_os = "none", target_env = "newlib", target_vendor = "espressif"))]
+pub mod none;
 
 pub mod raw;

--- a/library/std/src/os/none/fs.rs
+++ b/library/std/src/os/none/fs.rs
@@ -1,0 +1,126 @@
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use crate::fs::Metadata;
+use crate::sys_common::AsInner;
+
+#[allow(deprecated)]
+use crate::os::none::raw;
+
+/// OS-specific extensions to [`fs::Metadata`].
+///
+/// [`fs::Metadata`]: crate::fs::Metadata
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_crtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_crtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_atime_nsec as i64
+        0
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_mtime_nsec as i64
+        0
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_ctime_nsec as i64
+        0
+    }
+    fn st_crtime(&self) -> i64 {
+        //self.as_inner().as_inner().st_crtime as i64
+        0
+    }
+    fn st_crtime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_crtime_nsec as i64
+        0
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}

--- a/library/std/src/os/none/mod.rs
+++ b/library/std/src/os/none/mod.rs
@@ -1,0 +1,6 @@
+//! Definitions for bare metal platforms that nevertheless do have a POSIX compatibility layer
+
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
+pub mod fs;
+pub mod raw;

--- a/library/std/src/os/none/raw.rs
+++ b/library/std/src/os/none/raw.rs
@@ -1,0 +1,74 @@
+//! Bare-metal (usually newlib based) raw type definitions
+
+#![stable(feature = "raw_ext", since = "1.1.0")]
+#![allow(deprecated)]
+
+use crate::os::raw::c_long;
+use crate::os::unix::raw::{gid_t, uid_t};
+
+// Use the direct definition of usize, instead of uintptr_t like in libc
+#[stable(feature = "pthread_t", since = "1.8.0")]
+pub type pthread_t = libc::pthread_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = libc::blkcnt_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = libc::blksize_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = libc::dev_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = libc::ino_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = libc::mode_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = libc::nlink_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = libc::off_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = libc::time_t;
+
+#[repr(C)]
+#[derive(Clone)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_atime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mtime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ctime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_ctime_nsec: c_long,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_crtime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_crtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blocks: blkcnt_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_type: u32,
+}

--- a/library/std/src/sys/unix/alloc.rs
+++ b/library/std/src/sys/unix/alloc.rs
@@ -85,6 +85,11 @@ cfg_if::cfg_if! {
         unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
             libc::aligned_alloc(layout.align(), layout.size()) as *mut u8
         }
+    } else if #[cfg(target_arch = "xtensa")] {
+        #[inline]
+        unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
+            libc::malloc(layout.size()) as *mut u8
+        }
     } else {
         #[inline]
         unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {

--- a/library/std/src/sys/unix/condvar.rs
+++ b/library/std/src/sys/unix/condvar.rs
@@ -30,7 +30,8 @@ impl Condvar {
         target_os = "ios",
         target_os = "l4re",
         target_os = "android",
-        target_os = "redox"
+        target_os = "redox",
+        target_os = "none"
     ))]
     pub unsafe fn init(&mut self) {}
 
@@ -39,7 +40,8 @@ impl Condvar {
         target_os = "ios",
         target_os = "l4re",
         target_os = "android",
-        target_os = "redox"
+        target_os = "redox",
+        target_os = "none"
     )))]
     pub unsafe fn init(&mut self) {
         use crate::mem::MaybeUninit;

--- a/library/std/src/sys/unix/env.rs
+++ b/library/std/src/sys/unix/env.rs
@@ -173,3 +173,14 @@ pub mod os {
     pub const EXE_SUFFIX: &str = "";
     pub const EXE_EXTENSION: &str = "";
 }
+
+#[cfg(all(target_os = "none", target_env = "newlib"))]
+pub mod os {
+    pub const FAMILY: &str = "unix";
+    pub const OS: &str = "none";
+    pub const DLL_PREFIX: &str = "lib";
+    pub const DLL_SUFFIX: &str = ".so";
+    pub const DLL_EXTENSION: &str = "so";
+    pub const EXE_SUFFIX: &str = "";
+    pub const EXE_EXTENSION: &str = "";
+}

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -1,5 +1,14 @@
 #![unstable(reason = "not public", issue = "none", feature = "fd")]
 
+#[cfg(all(target_os = "none", target_vendor = "espressif"))]
+use crate::lazy::{SyncLazy};
+
+#[cfg(all(target_os = "none", target_vendor = "espressif"))]
+use crate::sync::{Mutex};
+
+#[cfg(all(target_os = "none", target_vendor = "espressif"))]
+use crate::collections::{HashMap};
+
 #[cfg(test)]
 mod tests;
 
@@ -66,6 +75,10 @@ const fn max_iov() -> usize {
     16 // The minimum value required by POSIX.
 }
 
+// A useful utility for platforms that do not natively suport duplication of file descriptors
+#[cfg(all(target_os = "none", target_vendor = "espressif"))]
+static MAP: SyncLazy<Mutex<HashMap<c_int, u32>>> = SyncLazy::new(|| Mutex::new(HashMap::new()));
+
 impl FileDesc {
     pub fn new(fd: c_int) -> FileDesc {
         assert_ne!(fd, -1i32);
@@ -79,6 +92,7 @@ impl FileDesc {
 
     /// Extracts the actual file descriptor without closing it.
     pub fn into_raw(self) -> c_int {
+        self.forget();
         let fd = self.fd;
         mem::forget(self);
         fd
@@ -91,6 +105,7 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
+    #[cfg(not(target_env = "newlib"))]
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let ret = cvt(unsafe {
             libc::readv(
@@ -100,11 +115,16 @@ impl FileDesc {
             )
         })?;
         Ok(ret as usize)
-    }
+     }
 
+     #[cfg(target_env = "newlib")]
+     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+         return crate::io::default_read_vectored(|b| self.read(b), bufs);
+     }
+ 
     #[inline]
     pub fn is_read_vectored(&self) -> bool {
-        true
+        cfg!(not(target_env = "newlib"))
     }
 
     pub fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
@@ -148,6 +168,7 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
+    #[cfg(not(target_env = "newlib"))]
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let ret = cvt(unsafe {
             libc::writev(
@@ -159,9 +180,14 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
+    #[cfg(target_env = "newlib")]
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        return crate::io::default_write_vectored(|b| self.write(b), bufs);
+    }
+
     #[inline]
     pub fn is_write_vectored(&self) -> bool {
-        true
+        cfg!(not(target_env = "newlib"))
     }
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
@@ -199,7 +225,7 @@ impl FileDesc {
     }
 
     #[cfg(not(any(
-        target_env = "newlib",
+        target_os = "none",
         target_os = "solaris",
         target_os = "illumos",
         target_os = "emscripten",
@@ -217,7 +243,6 @@ impl FileDesc {
         }
     }
     #[cfg(any(
-        target_env = "newlib",
         target_os = "solaris",
         target_os = "illumos",
         target_os = "emscripten",
@@ -237,6 +262,10 @@ impl FileDesc {
             }
             Ok(())
         }
+    }
+    #[cfg(target_os = "none")]
+    pub fn set_cloexec(&self) -> io::Result<()> {
+        Ok(())
     }
 
     #[cfg(target_os = "linux")]
@@ -264,12 +293,60 @@ impl FileDesc {
         }
     }
 
+    #[cfg(all(target_os = "none", target_vendor = "espressif"))]
+    pub fn duplicate(&self) -> io::Result<FileDesc> {
+        self.add_ref();
+        Ok(FileDesc::new(self.fd))
+    }
+
+    #[cfg(not(all(target_os = "none", target_vendor = "espressif")))]
     pub fn duplicate(&self) -> io::Result<FileDesc> {
         // We want to atomically duplicate this file descriptor and set the
         // CLOEXEC flag, and currently that's done via F_DUPFD_CLOEXEC. This
         // is a POSIX flag that was added to Linux in 2.6.24.
         let fd = cvt(unsafe { libc::fcntl(self.raw(), libc::F_DUPFD_CLOEXEC, 0) })?;
         Ok(FileDesc::new(fd))
+    }
+
+    #[cfg(all(target_os = "none", target_vendor = "espressif"))]
+    fn add_ref(&self) {
+        let mut map = MAP.lock().unwrap();
+        match map.get_mut(&self.fd) {
+            Some(refcnt) => {
+                *refcnt = *refcnt + 1;
+            },
+            None => {
+                map.insert(self.fd, 2);
+            }
+        };
+    }
+
+    fn remove_ref(&self) -> bool {
+        #[cfg(all(target_os = "none", target_vendor = "espressif"))]
+        {
+            let mut map = MAP.lock().unwrap();
+            match map.get_mut(&self.fd) {
+                Some(refcnt) => {
+                    *refcnt = *refcnt - 1;
+                    let close = *refcnt == 1;
+                    if close {
+                        map.remove(&self.fd);
+                    }
+                    close
+                },
+                None => true
+            }
+        }
+
+        #[cfg(not(all(target_os = "none", target_vendor = "espressif")))]
+        true
+    }
+
+    fn forget(&self) {
+        #[cfg(all(target_os = "none", target_vendor = "espressif"))]
+        {
+            MAP.lock().unwrap().remove(&self.fd);
+        }
     }
 }
 
@@ -297,6 +374,8 @@ impl Drop for FileDesc {
         // the file descriptor was closed or not, and if we retried (for
         // something like EINTR), we might close another valid file descriptor
         // opened after we closed ours.
-        let _ = unsafe { libc::close(self.fd) };
+        if self.remove_ref() {
+            let _ = unsafe { libc::close(self.fd) };
+        }
     }
 }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1,5 +1,4 @@
 use crate::os::unix::prelude::*;
-
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
 use crate::io::{self, Error, ErrorKind, IoSlice, IoSliceMut, SeekFrom};
@@ -297,7 +296,7 @@ impl FileAttr {
 
 #[cfg(not(target_os = "netbsd"))]
 impl FileAttr {
-    #[cfg(not(target_os = "vxworks"))]
+    #[cfg(all(not(target_os = "vxworks"), not(target_env = "newlib")))]
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_mtime as libc::time_t,
@@ -305,7 +304,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(target_os = "vxworks")]
+    #[cfg(any(target_os = "vxworks", target_env = "newlib"))]
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_mtime as libc::time_t,
@@ -313,7 +312,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(not(target_os = "vxworks"))]
+    #[cfg(all(not(target_os = "vxworks"), not(target_env = "newlib")))]
     pub fn accessed(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_atime as libc::time_t,
@@ -321,7 +320,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(target_os = "vxworks")]
+    #[cfg(any(target_os = "vxworks", target_env = "newlib"))]
     pub fn accessed(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_atime as libc::time_t,
@@ -594,7 +593,8 @@ impl DirEntry {
         target_os = "l4re",
         target_os = "fuchsia",
         target_os = "redox",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_env = "newlib"
     ))]
     pub fn ino(&self) -> u64 {
         self.entry.d_ino as u64
@@ -633,7 +633,8 @@ impl DirEntry {
         target_os = "emscripten",
         target_os = "l4re",
         target_os = "haiku",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_env = "newlib"
     ))]
     fn name_bytes(&self) -> &[u8] {
         unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
@@ -1082,7 +1083,7 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
     let original = cstr(original)?;
     let link = cstr(link)?;
     cfg_if::cfg_if! {
-        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android"))] {
+        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android", target_env = "newlib"))] {
             // VxWorks, Redox, and old versions of Android lack `linkat`, so use
             // `link` instead. POSIX leaves it implementation-defined whether
             // `link` follows symlinks, so rely on the `symlink_hard_link` test
@@ -1164,6 +1165,18 @@ fn open_from(from: &Path) -> io::Result<(crate::fs::File, crate::fs::Metadata)> 
     Ok((reader, metadata))
 }
 
+#[cfg(target_os = "none")]
+fn open_to_and_set_permissions(
+    to: &Path,
+    reader_metadata: crate::fs::Metadata,
+) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
+    use crate::fs::OpenOptions;
+    let writer = OpenOptions::new().open(to)?;
+    let writer_metadata = writer.metadata()?;
+    Ok((writer, writer_metadata))
+}
+
+#[cfg(not(target_os = "none"))]
 fn open_to_and_set_permissions(
     to: &Path,
     reader_metadata: crate::fs::Metadata,

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -33,15 +33,19 @@ pub use crate::os::openbsd as platform;
 pub use crate::os::redox as platform;
 #[cfg(all(not(doc), target_os = "solaris"))]
 pub use crate::os::solaris as platform;
+#[cfg(all(not(doc), all(target_os = "none", target_env = "newlib")))]
+pub use crate::os::none as platform;
 
 pub use self::rand::hashmap_random_keys;
 pub use libc::strlen;
 
+#[cfg(not(target_os = "none"))]
 #[macro_use]
 pub mod weak;
 
 pub mod alloc;
 pub mod android;
+#[cfg_attr(target_os = "none", path = "../unsupported/args.rs")]
 pub mod args;
 pub mod cmath;
 pub mod condvar;
@@ -59,6 +63,8 @@ pub mod memchr;
 pub mod mutex;
 #[cfg(not(target_os = "l4re"))]
 pub mod net;
+#[cfg(all(target_os = "none", target_env = "newlib", target_vendor = "espressif"))]
+mod net_lwip;
 #[cfg(target_os = "l4re")]
 pub use self::l4re::net;
 pub mod os;
@@ -66,6 +72,7 @@ pub mod path;
 pub mod pipe;
 pub mod process;
 pub mod rand;
+#[cfg_attr(target_env = "newlib", path = "../wasm/rwlock_atomics.rs")]
 pub mod rwlock;
 pub mod stack_overflow;
 pub mod stdio;
@@ -76,7 +83,11 @@ pub mod time;
 
 pub use crate::sys_common::os_str_bytes as os_str;
 
-#[cfg(not(test))]
+#[cfg(all(not(test), target_os = "none"))]
+pub fn init() {
+}
+
+#[cfg(all(not(test), not(target_os = "none")))]
 pub fn init() {
     // The standard streams might be closed on application startup. To prevent
     // std::io::{stdin, stdout,stderr} objects from using other unrelated file

--- a/library/std/src/sys/unix/mutex.rs
+++ b/library/std/src/sys/unix/mutex.rs
@@ -15,7 +15,7 @@ const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0xffffffff;
 #[cfg(not(all(target_os = "none", target_vendor = "espressif")))]
 pub type pthread_mutex_t = libc::pthread_mutex_t;
 #[cfg(not(all(target_os = "none", target_vendor = "espressif")))]
-const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = libc::pthread_mutex_t;
+const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = libc::PTHREAD_MUTEX_INITIALIZER;
 
 pub struct Mutex {
     inner: UnsafeCell<pthread_mutex_t>,

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -9,7 +9,7 @@ use crate::sys_common::net::{getsockopt, setsockopt, sockaddr_to_addr};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::time::{Duration, Instant};
 
-use libc::{c_int, c_void, size_t, sockaddr, socklen_t, EAI_SYSTEM, MSG_PEEK};
+use libc::{c_int, c_void, size_t, sockaddr, socklen_t, MSG_PEEK};
 
 pub use crate::sys::{cvt, cvt_r};
 
@@ -30,13 +30,19 @@ pub fn cvt_gai(err: c_int) -> io::Result<()> {
     // We may need to trigger a glibc workaround. See on_resolver_failure() for details.
     on_resolver_failure();
 
-    if err == EAI_SYSTEM {
+    #[cfg(not(all(target_os = "none", target_env = "newlib", target_vendor = "espressif")))]
+    if err == libc::EAI_SYSTEM {
         return Err(io::Error::last_os_error());
     }
 
+    #[cfg(not(all(target_os = "none", target_env = "newlib", target_vendor = "espressif")))]
     let detail = unsafe {
         str::from_utf8(CStr::from_ptr(libc::gai_strerror(err)).to_bytes()).unwrap().to_owned()
     };
+    
+    #[cfg(all(target_os = "none", target_env = "newlib", target_vendor = "espressif"))]
+    let detail = "";
+
     Err(io::Error::new(
         io::ErrorKind::Other,
         &format!("failed to lookup address information: {}", detail)[..],

--- a/library/std/src/sys/unix/net_lwip.rs
+++ b/library/std/src/sys/unix/net_lwip.rs
@@ -1,0 +1,72 @@
+// A set of definitions useful for bare metal platforms, where the LwIP stack is compiled with the "lwip_"-prefixed function variants
+// The ESP-IDF SDK of Espressif is one such example
+
+use libc::*;
+
+extern "C" {
+    fn lwip_accept(s: libc::c_int, addr: *mut libc::sockaddr, addrlen: *mut libc::socklen_t) -> libc::c_int;
+    fn lwip_bind(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int;
+    fn lwip_shutdown(s: libc::c_int, how: libc::c_int) -> libc::c_int;
+
+    fn lwip_getpeername(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int;
+    fn lwip_getsockname(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int;
+    
+    fn lwip_setsockopt(s: libc::c_int, level: libc::c_int, optname: libc::c_int, opval: *const libc::c_void, optlen: libc::socklen_t) -> libc::c_int;
+    fn lwip_getsockopt(s: libc::c_int, level: libc::c_int, optname: libc::c_int, opval: *mut libc::c_void, optlen: *mut libc::socklen_t) -> libc::c_int;
+    
+    fn lwip_close(s: libc::c_int) -> libc::c_int;
+    
+    fn lwip_connect(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int;
+    fn lwip_listen(s: libc::c_int, backlog: libc::c_int) -> libc::c_int;
+
+    fn lwip_recvmsg(sockfd: libc::c_int, msg: *mut libc::msghdr, flags: libc::c_int) -> libc::size_t;
+    fn lwip_recv(s: libc::c_int, mem: *mut libc::c_void, len: libc::size_t, flags: libc::c_int) -> libc::size_t;
+    fn lwip_recvfrom(s: libc::c_int, mem: *mut libc::c_void, len: libc::size_t, flags: libc::c_int, from: *mut libc::sockaddr, fromlen: *mut libc::socklen_t) -> libc::size_t;
+    
+    fn lwip_send(s: libc::c_int, dataptr: *const libc::c_void, size: libc::size_t, flags: libc::c_int) -> libc::size_t;
+    fn lwip_sendmsg(s: libc::c_int, message: *const libc::msghdr, flags: libc::c_int) -> libc::size_t;
+    fn lwip_sendto(s: libc::c_int, dataptr: *const libc::c_void, size: libc::size_t, flags: libc::c_int, to: *const libc::sockaddr, tolen: libc::socklen_t) -> libc::size_t;
+    
+    fn lwip_socket(domain: libc::c_int, typest: libc::c_int, protocol: libc::c_int) -> libc::c_int;
+    fn lwip_select(maxfdp1: libc::c_int, readset: *mut libc::fd_set, writeset: *mut libc::fd_set, exceptset: *mut libc::fd_set, timeout: *mut libc::timeval) -> libc::c_int;
+    fn lwip_ioctl(s: libc::c_int, cmd: libc::c_long, argp: *mut libc::c_void) -> libc::c_int;
+
+    fn lwip_gethostbyname_r(name: *const libc::c_char, ret: *mut libc::hostent, buf: *mut libc::c_char, buflen: libc::size_t, result: *mut *mut libc::hostent, h_errnop: *mut libc::c_int) -> libc::c_int;
+    fn lwip_gethostbyname(name: *const libc::c_char) -> *mut libc::hostent;
+
+    fn lwip_freeaddrinfo(ai: *mut libc::addrinfo) -> libc::c_void;
+    fn lwip_getaddrinfo(nodename: *const libc::c_char, servname: *const libc::c_char, hints: *const libc::addrinfo, res: *mut *mut libc::addrinfo) -> libc::c_int;
+}
+
+#[no_mangle] pub extern "C" fn accept(s: libc::c_int, addr: *mut libc::sockaddr, addrlen: *mut libc::socklen_t) -> libc::c_int {unsafe {lwip_accept(s, addr, addrlen)}}
+#[no_mangle] pub extern "C" fn bind(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int {unsafe {lwip_bind(s, name, namelen)}}
+#[no_mangle] pub extern "C" fn shutdown(s: libc::c_int, how: libc::c_int) -> libc::c_int {unsafe {lwip_shutdown(s, how)}}
+
+#[no_mangle] pub extern "C" fn getpeername(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int {unsafe {lwip_getpeername(s, name, namelen)}}
+#[no_mangle] pub extern "C" fn getsockname(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int {unsafe {lwip_getsockname(s, name, namelen)}}
+    
+#[no_mangle] pub extern "C" fn setsockopt(s: libc::c_int, level: libc::c_int, optname: libc::c_int, opval: *const libc::c_void, optlen: libc::socklen_t) -> libc::c_int {unsafe {lwip_setsockopt(s, level, optname, opval, optlen)}}
+#[no_mangle] pub extern "C" fn getsockopt(s: libc::c_int, level: libc::c_int, optname: libc::c_int, opval: *mut libc::c_void, optlen: *mut libc::socklen_t) -> libc::c_int {unsafe {lwip_getsockopt(s, level, optname, opval, optlen)}}
+    
+#[no_mangle] pub extern "C" fn closesocket(s: libc::c_int) -> libc::c_int {unsafe {lwip_close(s)}}
+    
+#[no_mangle] pub extern "C" fn connect(s: libc::c_int, name: *const libc::sockaddr, namelen: libc::socklen_t) -> libc::c_int {unsafe {lwip_connect(s, name, namelen)}}
+#[no_mangle] pub extern "C" fn listen(s: libc::c_int, backlog: libc::c_int) -> libc::c_int {unsafe {lwip_listen(s, backlog)}}
+
+#[no_mangle] pub extern "C" fn recvmsg(sockfd: libc::c_int, msg: *mut libc::msghdr, flags: libc::c_int) -> libc::size_t {unsafe {lwip_recvmsg(sockfd, msg, flags)}}
+#[no_mangle] pub extern "C" fn recv(s: libc::c_int, mem: *mut libc::c_void, len: libc::size_t, flags: libc::c_int) -> libc::size_t {unsafe {lwip_recv(s, mem, len, flags)}}
+#[no_mangle] pub extern "C" fn recvfrom(s: libc::c_int, mem: *mut libc::c_void, len: libc::size_t, flags: libc::c_int, from: *mut libc::sockaddr, fromlen: *mut libc::socklen_t) -> libc::size_t {unsafe {lwip_recvfrom(s, mem, len, flags, from, fromlen)}}
+    
+#[no_mangle] pub extern "C" fn send(s: libc::c_int, dataptr: *const libc::c_void, size: libc::size_t, flags: libc::c_int) -> libc::size_t {unsafe {lwip_send(s, dataptr, size, flags)}}
+#[no_mangle] pub extern "C" fn sendmsg(s: libc::c_int, message: *const libc::msghdr, flags: libc::c_int) -> libc::size_t {unsafe {lwip_sendmsg(s, message, flags)}}
+#[no_mangle] pub extern "C" fn sendto(s: libc::c_int, dataptr: *const libc::c_void, size: libc::size_t, flags: libc::c_int, to: *const libc::sockaddr, tolen: libc::socklen_t) -> libc::size_t {unsafe {lwip_sendto(s, dataptr, size, flags, to, tolen)}}
+    
+#[no_mangle] pub extern "C" fn socket(domain: libc::c_int, typest: libc::c_int, protocol: libc::c_int) -> libc::c_int {unsafe {lwip_socket(domain, typest, protocol)}}
+#[no_mangle] pub extern "C" fn select(maxfdp1: libc::c_int, readset: *mut libc::fd_set, writeset: *mut libc::fd_set, exceptset: *mut libc::fd_set, timeout: *mut libc::timeval) -> libc::c_int {unsafe {lwip_select(maxfdp1, readset, writeset, exceptset, timeout)}}
+#[no_mangle] pub extern "C" fn ioctlsocket(s: libc::c_int, cmd: libc::c_long, argp: *mut libc::c_void) -> libc::c_int {unsafe {lwip_ioctl(s, cmd, argp)}}
+
+#[no_mangle] pub extern "C" fn gethostbyname_r(name: *const libc::c_char, ret: *mut libc::hostent, buf: *mut libc::c_char, buflen: libc::size_t, result: *mut *mut libc::hostent, h_errnop: *mut libc::c_int) -> libc::c_int {unsafe {lwip_gethostbyname_r(name, ret, buf, buflen, result, h_errnop)}}
+#[no_mangle] pub extern "C" fn gethostbyname(name: *const libc::c_char) -> *mut libc::hostent {unsafe {lwip_gethostbyname(name)}}
+
+#[no_mangle] pub extern "C" fn freeaddrinfo(ai: *mut libc::addrinfo) -> libc::c_void {unsafe {lwip_freeaddrinfo(ai)}}
+#[no_mangle] pub extern "C" fn getaddrinfo(nodename: *const libc::c_char, servname: *const libc::c_char, hints: *const libc::addrinfo, res: *mut *mut libc::addrinfo) -> libc::c_int {unsafe {lwip_getaddrinfo(nodename, servname, hints, res)}}

--- a/library/std/src/sys/unix/net_lwip.rs
+++ b/library/std/src/sys/unix/net_lwip.rs
@@ -62,7 +62,7 @@ extern "C" {
 #[no_mangle] pub extern "C" fn sendto(s: libc::c_int, dataptr: *const libc::c_void, size: libc::size_t, flags: libc::c_int, to: *const libc::sockaddr, tolen: libc::socklen_t) -> libc::size_t {unsafe {lwip_sendto(s, dataptr, size, flags, to, tolen)}}
     
 #[no_mangle] pub extern "C" fn socket(domain: libc::c_int, typest: libc::c_int, protocol: libc::c_int) -> libc::c_int {unsafe {lwip_socket(domain, typest, protocol)}}
-#[no_mangle] pub extern "C" fn select(maxfdp1: libc::c_int, readset: *mut libc::fd_set, writeset: *mut libc::fd_set, exceptset: *mut libc::fd_set, timeout: *mut libc::timeval) -> libc::c_int {unsafe {lwip_select(maxfdp1, readset, writeset, exceptset, timeout)}}
+// Defined by ESP-IDF #[no_mangle] pub extern "C" fn select(maxfdp1: libc::c_int, readset: *mut libc::fd_set, writeset: *mut libc::fd_set, exceptset: *mut libc::fd_set, timeout: *mut libc::timeval) -> libc::c_int {unsafe {lwip_select(maxfdp1, readset, writeset, exceptset, timeout)}}
 #[no_mangle] pub extern "C" fn ioctlsocket(s: libc::c_int, cmd: libc::c_long, argp: *mut libc::c_void) -> libc::c_int {unsafe {lwip_ioctl(s, cmd, argp)}}
 
 #[no_mangle] pub extern "C" fn gethostbyname_r(name: *const libc::c_char, ret: *mut libc::hostent, buf: *mut libc::c_char, buflen: libc::size_t, result: *mut *mut libc::hostent, h_errnop: *mut libc::c_int) -> libc::c_int {unsafe {lwip_gethostbyname_r(name, ret, buf, buflen, result, h_errnop)}}

--- a/library/std/src/sys/unix/process/mod.rs
+++ b/library/std/src/sys/unix/process/mod.rs
@@ -4,11 +4,14 @@ pub use crate::ffi::OsString as EnvKey;
 pub use crate::sys_common::process::CommandEnvs;
 
 mod process_common;
-#[cfg(not(target_os = "fuchsia"))]
+#[cfg(all(not(target_os = "fuchsia"), not(target_os = "none")))]
 #[path = "process_unix.rs"]
 mod process_inner;
 #[cfg(target_os = "fuchsia")]
 #[path = "process_fuchsia.rs"]
+mod process_inner;
+#[cfg(target_os = "none")]
+#[path = "process_unsupported.rs"]
 mod process_inner;
 #[cfg(target_os = "fuchsia")]
 mod zircon;

--- a/library/std/src/sys/unix/process/process_unsupported.rs
+++ b/library/std/src/sys/unix/process/process_unsupported.rs
@@ -1,0 +1,110 @@
+use crate::ffi::OsStr;
+use crate::fmt;
+use crate::io;
+use crate::marker::PhantomData;
+use crate::path::Path;
+use crate::sys::fs::File;
+use crate::sys::pipe::AnonPipe;
+use crate::sys_common::process::{CommandEnv, CommandEnvs};
+use crate::ffi::{CStr, CString, OsString};
+
+pub use crate::ffi::OsString as EnvKey;
+
+use crate::sys::process::process_common::*;
+
+use libc::{c_char, c_int, gid_t, uid_t, EXIT_FAILURE, EXIT_SUCCESS};
+
+#[path = "../../unsupported/common.rs"]
+#[deny(unsafe_op_in_unsafe_fn)]
+mod unsupported;
+
+use unsupported::*;
+
+impl Command {
+    pub fn spawn(
+        &mut self,
+        _default: Stdio,
+        _needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
+        unsupported()
+    }
+    
+    pub fn exec(&mut self, default: Stdio) -> io::Error {
+        unsupported_err()
+    }
+}
+
+pub struct Process(Void);
+
+impl Process {
+    pub fn id(&self) -> u32 {
+        match self.0 {}
+    }
+
+    pub fn kill(&mut self) -> io::Result<()> {
+        match self.0 {}
+    }
+
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        match self.0 {}
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        match self.0 {}
+    }
+}
+
+pub struct ExitStatus(Void);
+
+impl ExitStatus {
+    pub fn success(&self) -> bool {
+        match self.0 {}
+    }
+
+    pub fn code(&self) -> Option<i32> {
+        match self.0 {}
+    }
+
+    fn exited(&self) -> bool {
+        match self.0 {}
+    }
+
+    pub fn signal(&self) -> Option<i32> {
+        match self.0 {}
+    }
+}
+
+impl Clone for ExitStatus {
+    fn clone(&self) -> ExitStatus {
+        match self.0 {}
+    }
+}
+
+/// Converts a raw `c_int` to a type-safe `ExitStatus` by wrapping it without copying.
+impl From<c_int> for ExitStatus {
+    fn from(a: c_int) -> ExitStatus {
+        panic!("Unsupported")
+    }
+}
+
+impl Copy for ExitStatus {}
+
+impl PartialEq for ExitStatus {
+    fn eq(&self, _other: &ExitStatus) -> bool {
+        match self.0 {}
+    }
+}
+
+impl Eq for ExitStatus {}
+
+impl fmt::Debug for ExitStatus {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {}
+    }
+}
+
+impl fmt::Display for ExitStatus {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {}
+    }
+}

--- a/library/std/src/sys/unix/rand.rs
+++ b/library/std/src/sys/unix/rand.rs
@@ -40,7 +40,20 @@ mod imp {
         unsafe { getrandom(buf.as_mut_ptr().cast(), buf.len(), libc::GRND_NONBLOCK) }
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(all(target_os = "none", target_vendor = "espressif"))]
+    fn getrandom_fill_bytes(buf: &mut [u8]) -> bool {
+        extern "C" {
+            fn esp_fill_random(buf: *mut libc::c_void, len: libc::size_t) -> libc::c_void;
+        }
+
+        unsafe {
+            esp_fill_random(buf.as_mut_ptr() as *mut libc::c_void, buf.len());
+        }
+
+        true // TODO: Return false if ESP32's WiFi or Bluetooth is not initialized
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android", all(target_os = "none", target_vendor = "espressif"))))]
     fn getrandom_fill_bytes(_buf: &mut [u8]) -> bool {
         false
     }

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -361,9 +361,9 @@ mod inner {
         }
     }
 
-    #[cfg(not(target_os = "dragonfly"))]
+    #[cfg(not(any(target_os = "dragonfly", target_env = "newlib")))]
     pub type clock_t = libc::c_int;
-    #[cfg(target_os = "dragonfly")]
+    #[cfg(any(target_os = "dragonfly", target_env = "newlib"))]
     pub type clock_t = libc::c_ulong;
 
     fn now(clock: clock_t) -> Timespec {

--- a/library/std/src/sys/wasm/rwlock_atomics.rs
+++ b/library/std/src/sys/wasm/rwlock_atomics.rs
@@ -111,7 +111,7 @@ impl RWLock {
     #[inline]
     unsafe fn initialize(&self) {
         if (!*self.initialized.get()) {
-            //(*self.cond.get()).init();
+            (*self.cond.get()).init();
             *self.initialized.get() = true;
         }
     }

--- a/library/std/src/sys_common/alloc.rs
+++ b/library/std/src/sys_common/alloc.rs
@@ -16,7 +16,8 @@ use crate::ptr;
     target_arch = "asmjs",
     target_arch = "wasm32",
     target_arch = "hexagon",
-    target_arch = "riscv32"
+    target_arch = "riscv32",
+    target_arch = "xtensa"
 )))]
 pub const MIN_ALIGN: usize = 8;
 #[cfg(all(any(

--- a/library/std/src/sys_common/io.rs
+++ b/library/std/src/sys_common/io.rs
@@ -1,4 +1,5 @@
-pub const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+// Bare metal platforms usually have very small amounts of RAM (in the order of hundreds of KB)
+pub const DEFAULT_BUF_SIZE: usize = (if cfg!(target_os = "none") {1} else {8}) * 1024;
 
 #[cfg(test)]
 #[allow(dead_code)] // not used on emscripten


### PR DESCRIPTION
My own STD changes. Rebased on top of `rust-lang:stable`, which is currently 1.50.0
Your `xtensa-support` branch is also tracking `rust-lang:stable` or maybe `mabezdev:xtensa-support`? Anyway, the latter is also good enough because it seems rebased now on top of `rust-lang:stable` anyway. If I'm not mistaken, it used to track `rust-lang:master`, but I might be mistaken.
 